### PR TITLE
Add full text search for pgsql #3

### DIFF
--- a/postgres/README.md
+++ b/postgres/README.md
@@ -1,0 +1,10 @@
+# PostgreSQL (WIP)
+
+## Installation
+
+```
+postgres=# set default_text_search_config = 'korean';
+postgres=# show default_text_search_config;
+
+postgres=# \i ts_mecab_ko.sql;
+```

--- a/postgres/mecab/ld.so.conf
+++ b/postgres/mecab/ld.so.conf
@@ -1,0 +1,2 @@
+include ld.so.conf.d/*.conf 
+/usr/local/lib

--- a/postgres/mecab/ts_mecab_ko.sql
+++ b/postgres/mecab/ts_mecab_ko.sql
@@ -1,0 +1,105 @@
+SET search_path = public;
+
+BEGIN;
+
+--
+-- Korean text parser
+--
+
+CREATE FUNCTION ts_mecabko_start(internal, int4)
+    RETURNS internal
+    AS '$libdir/ts_mecab_ko' -- '/usr/local/lib/libmecab.so.2'
+    LANGUAGE 'c' STRICT;
+
+CREATE FUNCTION ts_mecabko_gettoken(internal, internal, internal)
+    RETURNS internal
+    AS '$libdir/ts_mecab_ko' -- '/usr/local/lib/libmecab.so.2'
+    LANGUAGE 'c' STRICT;
+
+CREATE FUNCTION ts_mecabko_end(internal)
+    RETURNS void
+    AS '$libdir/ts_mecab_ko' -- '/usr/local/lib/libmecab.so.2'
+    LANGUAGE 'c' STRICT;
+
+CREATE TEXT SEARCH PARSER korean (
+    START    = ts_mecabko_start,
+    GETTOKEN = ts_mecabko_gettoken,
+    END      = ts_mecabko_end,
+    HEADLINE = pg_catalog.prsd_headline,
+    LEXTYPES = pg_catalog.prsd_lextype
+);
+COMMENT ON TEXT SEARCH PARSER korean IS
+    'korean word parser';
+
+--
+-- Korean text lexizer
+--
+
+CREATE FUNCTION ts_mecabko_lexize(internal, internal, internal, internal)
+    RETURNS internal
+    AS '$libdir/ts_mecab_ko' -- '/usr/local/lib/libmecab.so.2'
+    LANGUAGE 'c' STRICT;
+
+CREATE TEXT SEARCH TEMPLATE mecabko (
+	LEXIZE = ts_mecabko_lexize
+);
+
+CREATE TEXT SEARCH DICTIONARY korean_stem (
+	TEMPLATE = mecabko
+);
+
+--
+-- Korean text configuration
+--
+
+CREATE TEXT SEARCH CONFIGURATION korean (PARSER = korean);
+COMMENT ON TEXT SEARCH CONFIGURATION korean IS
+    'configuration for korean language';
+
+ALTER TEXT SEARCH CONFIGURATION korean ADD MAPPING
+    FOR email, url, url_path, host, file, version,
+        sfloat, float, int, uint,
+        numword, hword_numpart, numhword
+    WITH simple;
+
+-- Default configuration is Korean-English.
+-- Replace english_stem if you use other language.
+ALTER TEXT SEARCH CONFIGURATION korean ADD MAPPING
+    FOR asciiword, hword_asciipart, asciihword
+    WITH english_stem;
+
+ALTER TEXT SEARCH CONFIGURATION korean ADD MAPPING
+    FOR word, hword_part, hword
+    WITH korean_stem;
+
+--
+-- Utility functions
+--
+
+CREATE FUNCTION mecabko_analyze(
+        text,
+        OUT word text,
+        OUT type text,
+        OUT part1st text,
+        OUT partlast text,
+        OUT pronounce text,
+        OUT conjtype text,
+        OUT conjugation text,
+        OUT basic text,
+        OUT detail text,
+        OUT lucene text)
+    RETURNS SETOF record
+    AS '$libdir/ts_mecab_ko' -- '/usr/local/lib/libmecab.so.2'
+    LANGUAGE 'c' IMMUTABLE STRICT;
+
+CREATE FUNCTION korean_normalize(text)
+    RETURNS text
+    AS '$libdir/ts_mecab_ko' -- '/usr/local/lib/libmecab.so.2'
+    LANGUAGE 'c' IMMUTABLE STRICT;
+
+CREATE FUNCTION hanja2hangul(text)
+    RETURNS text
+    AS '$libdir/ts_mecab_ko' -- '/usr/local/lib/libmecab.so.2'
+    LANGUAGE 'c' IMMUTABLE STRICT;
+
+COMMIT;


### PR DESCRIPTION
## 기존 상황

- mecab를 postgis 컨테이너에 설치

## 업데이트 내용

### 중요

- mecab 커스텀 함수 실행
- pgsql에서 select문 실행

### 일반

- ldconfig로 라이브러리 링크 추가

## 관련이슈

- #3